### PR TITLE
#66 cannot unmarshal string into Go value of type basic.Info 에러 해결하기

### DIFF
--- a/basic/string_to_struct.go
+++ b/basic/string_to_struct.go
@@ -21,12 +21,12 @@ func StringToStruct() {
 }`
 
 	structInfo := Info{}
-	byteContent, _ := json.Marshal(str)
-
-	err := json.Unmarshal(byteContent, &structInfo)
+	err := json.Unmarshal([]byte(str), &structInfo)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println("Unmarshal : ", err)
 	}
 
 	fmt.Println(structInfo.Id)
+	fmt.Println(structInfo.NickName)
+	fmt.Println(structInfo.ReservationNo)
 }


### PR DESCRIPTION
#66 